### PR TITLE
Add interfaces for a generic PMU counter control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.ko*
+*.cmd
+*.mod*
+*.o
+Module.symvers
+modules.order

--- a/README.md
+++ b/README.md
@@ -1,0 +1,142 @@
+ARMv8 Performance Counters management module
+==========================================
+
+This module allows user to control access to ARMv8 PMU counters from userspace.
+
+It was initially created just for enabling userspace access to *Performance Monitors Cycle Count Register* (**PMCCNTR_EL0**) for use in dataplane software such as [DPDK](http://dpdk.org/dev/patchwork/patch/15225/) framework. It has been later extended to provide a general purpose interface for managing ARMv8 PMU counters.
+
+## Compilation
+
+```sh
+git clone https://github.com/jerinjacobk/armv8_pmu_cycle_counter_el0
+cd armv8_pmu_cycle_counter_el0
+# If compiling natively on ARMv8 host
+make
+# If cross compiling pass arguments as make arguments, not env vars
+make CROSS_COMPILE={cross_compiler_prefix} ARCH=arm64 KDIR=/path/to/kernel/sources
+```
+
+## Usage
+
+Next module has to be copied to the target board in question if it was cross-compiled. Next load it:
+
+```sh
+sudo insmod pmu_el0_cycle_counter.ko
+```
+
+Loading the module will enable userspace access to **PMCCNTR** counter. Unloading this module will disable userspace access to **PMCCNTR**.
+
+The **PMCCNTR** can be read in the application with:
+
+```c
+static inline uint64_t
+read_pmccntr(void)
+{
+	uint64_t val;
+	asm volatile("mrs %0, pmccntr_el0" : "=r"(val));
+	return val;
+}
+```
+
+Additionally module creates a device (`/dev/pmuctl`) which can be used to enable/disable access to PMU counters (currently only **PMCCNTR** is supported). This device supports the following interfaces:
+
+1. `read()` - Dump current counter configuration. It is preferred to read all data in one call as the data may change in between `read` syscalls:
+
+    ```sh
+    $ cat /dev/pmuctl
+    PMCCNTR=1
+    ```
+
+2. `write()` - Modify the configuration of a particular counter. The write buffer should have the `name=value` format. Both `name` and `value` are counter specific and described in the next chapter. Below is an example of how to use this:
+
+    ```sh
+    echo "PMCCNTR=1" > /dev/pmuctl
+    ```
+
+3. `ioctl()` - Similar to `write()` but intended for use in user applications rather than scripts. The list of supported ioctls is located in `pmuctl.h` header. Below is an example of how to use this interface:
+
+    ```c
+    struct pmuctl_pmccntr_data arg = { .enable = 0 };
+    int fd = open("/dev/pmuctl", O_RDONLY);
+    if (ioctl(fd, PMU_IOC_PMCCNTR, &arg)) {
+        /* error handling */
+    }
+    ```
+
+### Supported PMU counters
+
+1. **Performance Monitors Cycle Count Register**: `name` is `PMCCNTR`, `value` is `0` to disable EL0 access, `1` to enable EL0 access.
+
+## Adding support for new counters
+
+To add support for managing a new counter, developer should do the following:
+
+1. Add a new value to `enum pmu_ctls` at the end, just before `PM_CTL_CNT`. This will be used to identify the new counter in read and write operations. I.e.:
+
+    ```c
+    enum pmu_ctls {
+        PM_CTL_PMCCNTR,
+        PM_CTL_NEW_CNTR, /* Short description */ // <- new entry
+        PM_CTL_CNT,
+    };
+    ```
+
+2. Write `read()` and `write()` handlers for the new counter and add a descriptor to the `struct pmu_ctl_cfg pmu_ctls` array in `pmu_el0_cycle_counter.c` file. New entry should be placed at the index matching the new entry in `enum pmu_ctls`. I.e.:
+
+    ```c
+    static ssize_t
+    new_cntr_show(char *arg, size_t size)
+    {
+        /* Dump configuration to arg buffer, up to size characters.
+         * Return number of written characters or negative error code.
+         */
+    }
+    static int
+    new_cntr_modify(const char *arg, size_t size)
+    {
+        /* Modify config according to value parsed from arg buffer
+         * of size length.
+         * Return 0 on success or a negative error code.
+         */
+    }
+    /* ... */
+    static struct pmu_ctl_cfg pmu_ctls[PM_CTL_CNT] = {
+        /* ... */
+        [PM_CTL_NEW_CNTR] = {
+            .name	= "NEW_CNTR",
+            .show	= new_cntr_show,
+            .modify	= new_cntr_modify
+        }
+    };
+    ```
+
+3. For `ioctl()` support, add the definition of new ioctl and its arguments to the `pmuctl.h` file using `PMUCTL_IOC_MAGIC` as the ioctl magic and new `enum pmu_ctls` as a sequence number and using macros in `<linux/ioctl.h>`. I.e.:
+
+    ```c
+    struct pmuctl_new_cntr_arg {
+        int some_argument;
+    };
+    /* ... */
+    #define PMU_IOC_NEW_CNTR \
+        _IOW(PMUCTL_IOC_MAGIC, PM_CTL_NEW_CNTR, struct pmuctl_new_cntr_arg)
+    ```
+
+4. Next add a case statement in `pmuctl_ioctl()` function in `pmu_el0_cycle_counter.c` file to handle the new ioctl, i.e.:
+
+    ```c
+    static long
+    pmuctl_ioctl(struct file *f, unsigned int cmd, unsigned long arg)
+    {
+        /* ... */
+        mutex_lock(&pmuctl_lock);
+        switch (cmd) {
+            /* ... */
+        case PMU_IOC_NEW_CNTR:
+            /* handle the ioctl() */
+            break;
+        /* ...*/
+        }
+        mutex_unlock(&pmuctl_lock);
+        return ret;
+    }
+    ```

--- a/pmu_el0_cycle_counter.c
+++ b/pmu_el0_cycle_counter.c
@@ -12,7 +12,7 @@
 static void
 enable_cycle_counter_el0(void* data)
 {
-        u64 val;
+	u64 val;
 	/* Disable cycle counter overflow interrupt */
 	asm volatile("msr pmintenset_el1, %0" : : "r" ((u64)(0 << 31)));
 	/* Enable cycle counter */
@@ -22,8 +22,8 @@ enable_cycle_counter_el0(void* data)
 	/* Clear cycle counter and start */
 	asm volatile("mrs %0, pmcr_el0" : "=r" (val));
 	val |= (BIT(0) | BIT(2));
-        isb();
-        asm volatile("msr pmcr_el0, %0" : : "r" (val));
+	isb();
+	asm volatile("msr pmcr_el0, %0" : : "r" (val));
 	val = BIT(27);
 	asm volatile("msr pmccfiltr_el0, %0" : : "r" (val));
 }

--- a/pmu_el0_cycle_counter.c
+++ b/pmu_el0_cycle_counter.c
@@ -4,10 +4,62 @@
 #include <linux/kernel.h>
 #include <linux/module.h>
 #include <linux/smp.h>
+#include <linux/miscdevice.h>
+#include <linux/slab.h>
+#include <linux/uaccess.h>
+#include <linux/fs.h>
+#include "pmuctl.h"
 
 #if !defined(__aarch64__)
 #error Module can only be compiled on ARM64 machines.
 #endif
+
+struct pmu_ctl_cfg {
+	const char	*name;
+	/* Display PMU ctl value/status. Include newline.
+	 * Return written chars on success.
+	 */
+	ssize_t		(*show)(char *arg, size_t size);
+	/* Modify PMU ctl according to user value. Return 0 on success */
+	int		(*modify)(const char *arg, size_t size);
+};
+
+/* ops for each pmu control */
+static ssize_t
+pmccntr_show(char *arg, size_t size);
+static int
+pmccntr_modify(const char *arg, size_t size);
+
+/* file ops */
+static ssize_t
+pmuctl_read(struct file *f, char __user *userbuf, size_t count, loff_t *ppos);
+static ssize_t
+pmuctl_write(struct file *f, const char __user *ubuf, size_t cnt, loff_t *off);
+static long
+pmuctl_ioctl(struct file *f, unsigned int cmd, unsigned long arg);
+
+static struct pmu_ctl_cfg pmu_ctls[PM_CTL_CNT] = {
+	[PM_CTL_PMCCNTR] = {
+		.name	= "PMCCNTR",
+		.show	= pmccntr_show,
+		.modify	= pmccntr_modify
+	}
+};
+
+static const struct file_operations pmuctl_fops = {
+	.owner		= THIS_MODULE,
+	.read		= pmuctl_read,
+	.write		= pmuctl_write,
+	.llseek		= generic_file_llseek,
+	.unlocked_ioctl	= pmuctl_ioctl,
+};
+
+static struct miscdevice pmuctl_dev = {
+	.minor		= MISC_DYNAMIC_MINOR,
+	.name		= "pmuctl",
+	.fops		= &pmuctl_fops
+};
+DEFINE_MUTEX(pmuctl_lock);
 
 static void
 enable_cycle_counter_el0(void* data)
@@ -38,17 +90,183 @@ disable_cycle_counter_el0(void* data)
 
 }
 
+static ssize_t
+pmccntr_show(char *arg, size_t size)
+{
+	u64 val;
+	int ret;
+
+	asm volatile("mrs %0, pmuserenr_el0" : "=r" (val));
+	ret = snprintf(arg, size, "PMCCNTR=%1d\n",
+		       ((val & (BIT(0) | BIT(2))) != 0 ? 1 : 0));
+	return (ret < size) ? ret : size;
+}
+
+static int
+pmccntr_modify(const char *arg, size_t size)
+{
+	long int val;
+
+	if (kstrtol(arg, 0, &val)) {
+		return -EINVAL;
+	}
+	if (val != 0)
+		on_each_cpu(enable_cycle_counter_el0, NULL, 1);
+	else
+		on_each_cpu(disable_cycle_counter_el0, NULL, 1);
+	return 0;
+}
+
+static ssize_t
+pmuctl_read(struct file *f, char __user *userbuf, size_t count, loff_t *ppos)
+{
+	char *buf, *cur;
+	ssize_t size;
+	int i;
+
+	if (*ppos > 0)
+		return 0;
+	if (count > PAGE_SIZE)
+		return -E2BIG;
+	buf = kzalloc(PAGE_SIZE, GFP_KERNEL);
+	if (buf == NULL)
+		return -ENOMEM;
+	cur = buf;
+
+	mutex_lock(&pmuctl_lock);
+	for (i = 0; i < PM_CTL_CNT; i++) {
+		if (pmu_ctls[i].show == NULL)
+			continue;
+
+		size = pmu_ctls[i].show(cur, count);
+		if (size < 0) {
+			goto err_free;
+		}
+		cur += size;
+		count -= size;
+	}
+	mutex_unlock(&pmuctl_lock);
+	size = simple_read_from_buffer(userbuf, count, ppos, buf, cur - buf);
+
+err_free:
+	kfree(buf);
+
+	return size;
+}
+
+static ssize_t
+pmuctl_write(struct file *f, const char __user *ubuf, size_t cnt, loff_t *off)
+{
+	char *buf, *name, *val;
+	int i, ret = -EIO;
+
+	if (cnt > PAGE_SIZE)
+		return -E2BIG;
+	buf = kzalloc(PAGE_SIZE, GFP_KERNEL);
+	if (buf == NULL)
+		return -ENOMEM;
+	if (copy_from_user(buf, ubuf, cnt)) {
+		ret = -EIO;
+		goto err_copy;
+	}
+
+	val = buf;
+	name = strim(strsep(&val, "="));
+	if (val == NULL) {
+		dev_err(pmuctl_dev.this_device, "Invalid write: %s\n", buf);
+		ret = -EINVAL;
+		goto err_parse;
+	}
+	val = strim(val);
+	for (i = 0; i < PM_CTL_CNT; i++) {
+		if (strcmp(pmu_ctls[i].name, name))
+			continue;
+		if (pmu_ctls[i].modify != NULL) {
+			ret = pmu_ctls[i].modify(val, cnt - (val - name));
+			if (ret == 0)
+				ret = cnt;
+		} else {
+			dev_err(pmuctl_dev.this_device,
+				"PMU %s not modifiable\n", pmu_ctls[i].name);
+			ret = -ENOTSUPP;
+		}
+		break;
+	}
+	if (i == PM_CTL_CNT) {
+		dev_err(pmuctl_dev.this_device, "Unknown PMU CTL: %s\n", name);
+		ret = -EINVAL;
+	}
+err_parse:
+err_copy:
+	kfree(buf);
+	return ret;
+}
+
+static long
+pmuctl_ioctl(struct file *f, unsigned int cmd, unsigned long arg)
+{
+	int err = 0;
+	struct pmuctl_pmccntr_data pmccntr;
+	int ret = 0;
+
+	if (_IOC_TYPE(cmd) != PMUCTL_IOC_MAGIC)
+		return -ENOTTY;
+
+	if (_IOC_DIR(cmd) & _IOC_READ)
+		err = !access_ok(VERIFY_WRITE, (void __user *)arg,
+				 _IOC_SIZE(cmd));
+	else if (_IOC_TYPE(cmd) & _IOC_WRITE)
+		err = !access_ok(VERIFY_READ, (void __user *)arg,
+				 _IOC_SIZE(cmd));
+
+	if (err)
+		return -EFAULT;
+
+	mutex_lock(&pmuctl_lock);
+	switch (cmd) {
+	case PMU_IOC_PMCCNTR: /* enable/disable pmccntr */
+		if (copy_from_user(&pmccntr, (void *)arg, _IOC_SIZE(cmd))) {
+			ret = -EIO;
+			break;
+		}
+		if (pmccntr.enable)
+			on_each_cpu(enable_cycle_counter_el0, NULL, 1);
+		else
+			on_each_cpu(disable_cycle_counter_el0, NULL, 1);
+		break;
+	default:
+		ret = -ENOTTY;
+	}
+	mutex_unlock(&pmuctl_lock);
+	return ret;
+}
+
 static int __init
 init(void)
 {
+	int ret;
+
+	ret = misc_register(&pmuctl_dev);
+	if (ret) {
+		printk(KERN_ERR "pmuctl - misc_register failed, err = %d\n",
+		       ret);
+		goto err_mist_register;
+	}
+
 	on_each_cpu(enable_cycle_counter_el0, NULL, 1);
+
 	return 0;
+
+err_mist_register:
+	return ret;
 }
 
 static void __exit
 fini(void)
 {
 	on_each_cpu(disable_cycle_counter_el0, NULL, 1);
+
+	misc_deregister(&pmuctl_dev);
 }
 
 MODULE_DESCRIPTION("Enables user-mode access to ARMv8 PMU counters");

--- a/pmuctl.h
+++ b/pmuctl.h
@@ -1,0 +1,19 @@
+#ifndef _PMUCTL_H
+#define _PMUCTL_H
+
+#define PMUCTL_IOC_MAGIC	0xF1
+
+/* List of PMU controls enabled by the driver. */
+enum pmu_ctls {
+	PM_CTL_PMCCNTR, /* Enable/disable PMCCNTR_EL0 */
+	PM_CTL_CNT, /* Keep this last! */
+};
+
+struct pmuctl_pmccntr_data {
+	int enable; /* 0 - disable, 1 - enable */
+};
+
+#define PMU_IOC_PMCCNTR \
+	_IOW(PMUCTL_IOC_MAGIC, PM_CTL_PMCCNTR, struct pmuctl_pmccntr_data)
+
+#endif


### PR DESCRIPTION
Add a small framework for configuring PMU counters while module is loaded. The configuration interfaces are centered around `/dev/pmuctl` and allow live change of counter configuration. Currently, as before, only `PMCCNTR` access in EL0 is supported.

It seems reasonable though that later on we might want to configure other ARMv8 PM counters for fast access in EL0 (i.e. `PMEVCNTR<n>_EL0`) so this framework takes care of displaying and modifying configuration of any named object. Developer needs only to provide a descriptor with new counter name and callbacks for displaying and modifying the configuration.