### PR TITLE
fix compile errors

### DIFF
--- a/pmu_el0_cycle_counter.c
+++ b/pmu_el0_cycle_counter.c
@@ -8,6 +8,7 @@
 #include <linux/slab.h>
 #include <linux/uaccess.h>
 #include <linux/fs.h>
+#include <linux/platform_device.h>
 #include "pmuctl.h"
 
 #if !defined(__aarch64__)


### PR DESCRIPTION
In my Linux distro (which is based on kernel 4.4.x + ubuntu16.04),
system reported below errors while run make:

root@right:~/tsc/armv8_pmu_cycle_counter_el0# make
make -C /lib/modules/4.4.131-20190505.kylin.server-generic/build
SUBDIRS=/home/kylin/tsc/armv8_pmu_cycle_counter_el0 modules
make[1]: 进入目录“/usr/src/kylin-headers-4.4.131-20190505-generic”
  CC [M]  /home/kylin/tsc/armv8_pmu_cycle_counter_el0/pmu_el0_cycle_counter.o
/home/kylin/tsc/armv8_pmu_cycle_counter_el0/pmu_el0_cycle_counter.c: In function ‘pmuctl_write’:
/home/kylin/tsc/armv8_pmu_cycle_counter_el0/pmu_el0_cycle_counter.c:176:3:
error: implicit declaration of function ‘dev_err’ [-Werror=implicit-function-declaration]
   dev_err(pmuctl_dev.this_device, "Invalid write: %s\n", buf);
   ^
cc1: some warnings being treated as errors
make[2]: *** [scripts/Makefile.build:284：/home/kylin/tsc/armv8_pmu_cycle_counter_el0/pmu_el0_cycle_counter.o] 错误 1
make[1]: *** [Makefile:1479：_module_/home/kylin/tsc/armv8_pmu_cycle_counter_el0] 错误 2
make[1]: 离开目录“/usr/src/kylin-headers-4.4.131-20190505-generic”
make: *** [Makefile:6：all] 错误 2

This patch add an explicit declaration to the function dev_err.

Signed-off-by: Jianhua Xie <xiejianhua.phytium.com.cn>