### PR TITLE
Fix compiling issue with kernel 5.0+

### DIFF
--- a/pmu_el0_cycle_counter.c
+++ b/pmu_el0_cycle_counter.c
@@ -9,6 +9,7 @@
 #include <linux/uaccess.h>
 #include <linux/fs.h>
 #include <linux/platform_device.h>
+#include <linux/version.h>
 #include "pmuctl.h"
 
 #if !defined(__aarch64__)
@@ -214,11 +215,21 @@ pmuctl_ioctl(struct file *f, unsigned int cmd, unsigned long arg)
 		return -ENOTTY;
 
 	if (_IOC_DIR(cmd) & _IOC_READ)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0)
 		err = !access_ok(VERIFY_WRITE, (void __user *)arg,
 				 _IOC_SIZE(cmd));
+#else
+		err = !access_ok((void __user *)arg,
+				 _IOC_SIZE(cmd));
+#endif
 	else if (_IOC_TYPE(cmd) & _IOC_WRITE)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0)
 		err = !access_ok(VERIFY_READ, (void __user *)arg,
 				 _IOC_SIZE(cmd));
+#else
+		err = !access_ok((void __user *)arg,
+				 _IOC_SIZE(cmd));
+#endif
 
 	if (err)
 		return -EFAULT;


### PR DESCRIPTION
Fix the following error:
_pmu_cycle_counter_el0/pmu_el0_cycle_counter.c:218:20: error: macro
"access_ok" passed 3 arguments, but takes just 2

The error is attributed to the kernel commit[1].

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/
commit/?id=96d4f267e40f9509e8a66e2b39e8b95655617693

Signed-off-by: Gavin Hu <gavin.hu@arm.com>