### PR TITLE
Follow the guide to build external modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,6 @@ KDIR	:= /lib/modules/$(shell uname -r)/build
 PWD	:= $(shell pwd)
 
 all:
-	$(MAKE) -C $(KDIR) SUBDIRS=$(PWD) modules
+	$(MAKE) -C $(KDIR) M=$(PWD) modules
 clean:
-	$(MAKE) -C $(KDIR) SUBDIRS=$(PWD) clean
+	$(MAKE) -C $(KDIR) M=$(PWD) clean


### PR DESCRIPTION
The old 'SUBDIRS=$(PWD)' works for kernel 4.x, but it does not
compile for kernel 5.x.

Follow the guide [1] to use 'M=$(PWD)' instead.

[1] https://www.kernel.org/doc/Documentation/kbuild/modules.txt

Signed-off-by: Gavin Hu <gavin.hu@arm.com>