### PR TITLE
Use correct register to disable overflow interrupt

### DIFF
--- a/pmu_el0_cycle_counter.c
+++ b/pmu_el0_cycle_counter.c
@@ -74,7 +74,7 @@ enable_cycle_counter_el0(void* data)
 {
 	u64 val;
 	/* Disable cycle counter overflow interrupt */
-	asm volatile("msr pmintenset_el1, %0" : : "r" ((u64)(0 << 31)));
+	asm volatile("msr pmintenclr_el1, %0" : : "r" ((u64)(1 << 31)));
 	/* Enable cycle counter */
 	asm volatile("msr pmcntenset_el0, %0" :: "r" BIT(31));
 	/* Enable user-mode access to cycle counters. */


### PR DESCRIPTION
Use PMINTENCLR_EL1 (Performance Monitors Interrupt Enable Clear
    register) instead of PMINTENSET_EL1 ( Performance Monitors Interrupt
    Enable Set register). Writing '0' to 'C' (bit 31 on
    PMINTENSET_EL1) has no effect.