### PR TITLE
adding license info to the files

### DIFF
--- a/pmu_el0_cycle_counter.c
+++ b/pmu_el0_cycle_counter.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0 */
 /*
  * Enable user-mode ARM performance counter access.
  */

--- a/pmuctl.h
+++ b/pmuctl.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: (BSD-3-Clause OR LGPL-2.1) */
 #ifndef _PMUCTL_H
 #define _PMUCTL_H
 


### PR DESCRIPTION
HI Jerin,
          The repo was missing license, which can be interpreted as proprietay code? We got it flagged by our legal team.

I am not changing the copyright. 
BTW - in DPDK we used the following as general purpose copyright
Copyright 2016 The DPDK contributors

Regards,
Hemant