### PR TITLE
Extend framework to support Counter-timer Kernel Control register access from user space

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-obj-m	:= pmu_el0_cycle_counter.o
+obj-m := pmu_el0_cycle_counter.o
+pmu_el0_cycle_counter-objs += armv8_pmu_el0_cycle_counter.o armv8_pmu_el0_timer_control.o
 KDIR	:= /lib/modules/$(shell uname -r)/build
 PWD	:= $(shell pwd)
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This module allows user to control access to ARMv8 PMU counters from userspace.
 
 It was initially created just for enabling userspace access to *Performance Monitors Cycle Count Register* (**PMCCNTR_EL0**) for use in dataplane software such as [DPDK](http://dpdk.org/dev/patchwork/patch/15225/) framework. It has been later extended to provide a general purpose interface for managing ARMv8 PMU counters.
 
+Further adding support to enable/disable user mode access to Counter Timer Kernel Control register.
+
 ## Compilation
 
 ```sh
@@ -66,6 +68,10 @@ Additionally module creates a device (`/dev/pmuctl`) which can be used to enable
 ### Supported PMU counters
 
 1. **Performance Monitors Cycle Count Register**: `name` is `PMCCNTR`, `value` is `0` to disable EL0 access, `1` to enable EL0 access.
+
+### Support for Counter-timer Kernel Control
+
+1. **Counter-timer Kernel Control Register**: `name` is `CNTKCTL, `value` is `0` to disable EL0 access, `1` to enable EL0 access.
 
 ## Adding support for new counters
 

--- a/armv8_pmu_el0_timer_control.c
+++ b/armv8_pmu_el0_timer_control.c
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright 2023 NXP
+ * Add support for Counter-timer Kernel Control register EL0 access
+ *
+ */
+
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/smp.h>
+#include <linux/uaccess.h>
+#include <linux/fs.h>
+#include <linux/platform_device.h>
+#include <linux/version.h>
+#include "pmuctl.h"
+
+#if !defined(__aarch64__)
+#error Module can only be compiled on ARM64 machines.
+#endif
+
+static void
+enable_timer_ctl_el0(void *data)
+{
+	u64 val;
+
+	/* Enable per cpu Physical/Virtual Timer Control EL0 access */
+	asm volatile("mrs %0, CNTKCTL_EL1" : "=r" (val));
+	asm volatile("isb" : :);
+	asm volatile("msr CNTKCTL_EL1, %0" : : "r"(val | BIT(9) | BIT(8)));
+}
+
+static void
+disable_timer_ctl_el0(void *data)
+{
+	u64 val;
+
+	/* Enable per cpu Physical/Virtual Timer Control EL0 access */
+	asm volatile("mrs %0, CNTKCTL_EL1" : "=r" (val));
+	asm volatile("isb" : :);
+	asm volatile("msr CNTKCTL_EL1, %0" : : "r"(val & 0xFF));
+}
+
+ssize_t
+pmcntkctl_show(char *arg, size_t size)
+{
+	u64 val;
+	int ret;
+
+	asm volatile("mrs %0, CNTKCTL_EL1" : "=r" (val));
+	ret = snprintf(arg, size, "CNTKCTL EL0 access = %1d\n",
+		       ((val & (BIT(8) | BIT(9))) != 0 ? 1 : 0));
+	return (ret < size) ? ret : size;
+}
+
+int
+pmcntkctl_modify(const char *arg, size_t size)
+{
+	long val;
+
+	if (kstrtol(arg, 0, &val))
+		return -EINVAL;
+
+	if (val != 0)
+		on_each_cpu(enable_timer_ctl_el0, NULL, 1);
+	else
+		on_each_cpu(disable_timer_ctl_el0, NULL, 1);
+	return 0;
+}
+
+void
+pm_cntkctl_handler(int enable)
+{
+	if (enable)
+		on_each_cpu(enable_timer_ctl_el0, NULL, 1);
+	else
+		on_each_cpu(disable_timer_ctl_el0, NULL, 1);
+}
+
+void
+pm_cntkctl_fini(void)
+{
+	/* Restore the physical timer control register to default state */
+	on_each_cpu(disable_timer_ctl_el0, NULL, 1);
+
+}
+
+MODULE_DESCRIPTION("Enable Physical Timer Control EL0 access");
+MODULE_LICENSE("GPL");

--- a/pmu_tmr_ctl.h
+++ b/pmu_tmr_ctl.h
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: (BSD-3-Clause OR LGPL-2.1) */
+#ifndef _PMU_TMR_CTL_H
+#define _PMU_TMR_CTL_H
+
+/* extern declarations for timer control handers */
+extern void pm_cntkctl_handler(int enable);
+extern void pm_cntkctl_fini(void);
+extern ssize_t pmcntkctl_show(char *arg, size_t size);
+extern int pmcntkctl_modify(const char *arg, size_t size);
+
+#endif

--- a/pmuctl.h
+++ b/pmuctl.h
@@ -7,6 +7,7 @@
 /* List of PMU controls enabled by the driver. */
 enum pmu_ctls {
 	PM_CTL_PMCCNTR, /* Enable/disable PMCCNTR_EL0 */
+	PM_CTL_CNTKCTL, /* Enable Physical Timer Control EL0 access */
 	PM_CTL_CNT, /* Keep this last! */
 };
 
@@ -16,5 +17,8 @@ struct pmuctl_pmccntr_data {
 
 #define PMU_IOC_PMCCNTR \
 	_IOW(PMUCTL_IOC_MAGIC, PM_CTL_PMCCNTR, struct pmuctl_pmccntr_data)
+#define PMU_IOC_CNTKCTL \
+	_IOW(PMUCTL_IOC_MAGIC, PM_CTL_CNTKCTL, struct pmuctl_pmccntr_data)
+
 
 #endif


### PR DESCRIPTION
While doing performance bench-marking using PMU, an issue of "Application cpu cycle spikes in timeboud 5G applications running on ARM" is seen. Context switching is the main reason for the spikes in cycle count when measured with PMU.

I have found out a solution for achieving hard real time behavior of a DPDK application on ARM by playing with core settings and by masking/unmasking "ARM per-core architected timer interrupts" which avoid these unwanted context switching on an isolated CPU.

Intention is that any DPDK or general application can enable this access via this kernel module and then mask/unmask arch_timer irq, using ARM "cntp_ctl_el0" register, around the Critical time bound processing piece of code.

Reference:
https://developer.arm.com/documentation/ddi0601/2020-12/AArch64-Registers/CNTKCTL-EL1--Counter-timer-Kernel-Control-register